### PR TITLE
Update build.gradle ( to solve zm_next_arrow.xml issue)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,10 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    packagingOptions {
+        pickFirst '**/*'
+    }
 }
 
 


### PR DESCRIPTION
makes it compatible with gradle 3.5+

## Problem:
These libs contain some duplicated files (zm_next_arrow.xml, and many mores)
lib/commonlib.aar
lib/mobilertc.aar

Duplicated files works with gradle 3.4 but failed to build with gradle 3.5

## Solve:
To solve the problem, we must explicitly tell gradle to `pickFirst` file when conflicting happended
```
packagingOptions {
        pickFirst '**/*'
}
```

This setting is backward compatible to gradle 3.4 as well.